### PR TITLE
Fix login/logout events getting lost

### DIFF
--- a/src/android/Game.java
+++ b/src/android/Game.java
@@ -480,10 +480,12 @@ public class Game extends CordovaPlugin implements GameHelper.GameHelperListener
 		return mHelper;		
 	}	
 	private void _login(){
+		cordova.setActivityResultCallback(this);
 		//getGameHelper().beginUserInitiatedSignIn();		
 		getGameHelper().onStart(this.cordova.getActivity());
 	}
-	private void _logout(){		
+	private void _logout(){
+		cordova.setActivityResultCallback(this);
 		//getGameHelper().signOut();
 		getGameHelper().onStop();
 	}

--- a/src/android/Game.java
+++ b/src/android/Game.java
@@ -617,6 +617,7 @@ public class Game extends CordovaPlugin implements GameHelper.GameHelperListener
 	}	
 	
 	private void _showLeaderboard(String leaderboardId){
+		cordova.setActivityResultCallback(this);
 		try {
 			//show a specific leaderboard
 			this.cordova.getActivity().startActivityForResult(Games.Leaderboards.getLeaderboardIntent(getGameHelper().getApiClient(), leaderboardId), 0);
@@ -627,6 +628,7 @@ public class Game extends CordovaPlugin implements GameHelper.GameHelperListener
 	}
 
 	private void _showLeaderboards(){
+		cordova.setActivityResultCallback(this);
 		try {
 			//show all leaderboards
 			this.cordova.getActivity().startActivityForResult(Games.Leaderboards.getAllLeaderboardsIntent(getGameHelper().getApiClient()), 0);
@@ -741,6 +743,7 @@ public class Game extends CordovaPlugin implements GameHelper.GameHelperListener
 	}
 	
 	private void _showAchievements(){
+		cordova.setActivityResultCallback(this);
 		this.cordova.getActivity().startActivityForResult(Games.Achievements.getAchievementsIntent(getGameHelper().getApiClient()), 0);		
 	}
 


### PR DESCRIPTION
In some cases no events were received that signaled a successful/failed/canceled login/logout. This happened because Cordova supports setting a single activity result callback via `setActivityResultCallback()` which may have been stolen by other plugins in the meantime. Setting this callback on each login/logout solves the issue.